### PR TITLE
Update stacktrace test fixture to for latest elixir

### DIFF
--- a/test/faktory_worker/error_formatter_test.exs
+++ b/test/faktory_worker/error_formatter_test.exs
@@ -29,7 +29,7 @@ defmodule FaktoryWorker.ErrorFormatterTest do
              }
     end
 
-    test "should return a formatted error for an a map with a message attribute" do
+    test "should return a formatted error for a map with a message attribute" do
       error = %{message: "It went bang!"}
 
       formatted_error = ErrorFormatter.format_error({error, @stacktrace}, 10)
@@ -41,7 +41,7 @@ defmodule FaktoryWorker.ErrorFormatterTest do
              }
     end
 
-    test "should return a formatted error for an a tuple with an atom error type" do
+    test "should return a formatted error for a tuple with an atom error type" do
       error = {:badmatch, "123"}
 
       formatted_error = ErrorFormatter.format_error({error, @stacktrace}, 10)

--- a/test/faktory_worker/error_formatter_test.exs
+++ b/test/faktory_worker/error_formatter_test.exs
@@ -6,17 +6,15 @@ defmodule FaktoryWorker.ErrorFormatterTest do
 
   describe "format_error/2" do
     @stacktrace [
-      {TestApp.Worker, :perform, 1, [file: 'lib/worker.ex', line: 9]},
-      {Task.Supervised, :invoke_mfa, 2, [file: 'lib/task/supervised.ex', line: 90]},
-      {Task.Supervised, :reply, 5, [file: 'lib/task/supervised.ex', line: 35]},
-      {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}
+      {TestApp.Worker, :raise_error, 1, [file: 'lib/worker.ex', line: 50]},
+      {TestApp.Worker, :do_work, 1, [file: 'lib/worker.ex', line: 37]},
+      {TestApp.Worker, :perform, 1, [file: 'lib/worker.ex', line: 9]}
     ]
 
     @formatted_stacktrace [
-      "lib/worker.ex:9: TestApp.Worker.perform/1",
-      "(elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2",
-      "(elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5",
-      "(stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3"
+      "lib/worker.ex:50: TestApp.Worker.raise_error/1",
+      "lib/worker.ex:37: TestApp.Worker.do_work/1",
+      "lib/worker.ex:9: TestApp.Worker.perform/1"
     ]
 
     test "should return a formatted error for an exception" do


### PR DESCRIPTION
Since updating to the latest Elixir and tooling the `ErrorFormatter` tests began to fail. The failure was caused by a change to how Elixir formats stacktrace lines for Elixir and Erlang standard library functions.

For example, prior to the update a stacktrace line would look like this.
```
(elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
```

Since updating Elixir now includes the version number in the stacktrace line.
```
(elixir 1.10.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
```

Since we don't actually care about the format of each stacktrace line and only that the lines were captured correctly, I have updated the fixture to use a stacktrace raised from application code.