### PR TITLE
Allow the jobtype field to be overriden

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -103,6 +103,8 @@ Below is the full structure of available options and a definition for each one.
 ```elixir
 [
   queue: String.t(),
+  jobtype: String.t(),
+  at: DateTime.t(),
   retry: pos_integer(),
   reserve_for: post_integer(),
   custom: map(),
@@ -113,6 +115,8 @@ Below is the full structure of available options and a definition for each one.
 ### Option Definitions
 
 - `queue` (default: `"default"`) - The name of the queue in Faktory to send jobs to.
+- `jobtype` (default: `__MODULE__`) - The type of job to send. This is used to determine how to process a job when fetched from Faktory.
+- `at` (relies on Faktory default) - The date and time Faktory should run the job.
 - `retry` (relies on Faktory default) - The number of times the job should retry if it fails.
 - `reserve_for` (relies on Faktory default) -The number of seconds the job is reserved for in Faktory before it is considered failed.
 - `custom` (relies on Faktory default) - A map of values to be included with the job when it is sent to Faktory.

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -84,7 +84,7 @@ defmodule FaktoryWorker.Job do
   # priority
   # backtrace
   # created_at
-  @optional_job_fields [:queue, :custom, :retry, :reserve_for, :at]
+  @optional_job_fields [:jobtype, :queue, :custom, :retry, :reserve_for, :at]
 
   defmacro __using__(using_opts \\ []) do
     alias FaktoryWorker.Job
@@ -150,6 +150,7 @@ defmodule FaktoryWorker.Job do
     end)
   end
 
+  defp is_valid_field_value?(:jobtype, value), do: is_binary(value)
   defp is_valid_field_value?(:queue, value), do: is_binary(value)
   defp is_valid_field_value?(:custom, value), do: is_map(value)
   defp is_valid_field_value?(:retry, value), do: is_integer(value)

--- a/test/faktory_worker/job/job_test.exs
+++ b/test/faktory_worker/job/job_test.exs
@@ -154,6 +154,22 @@ defmodule FaktoryWorker.Job.JobTest do
 
       assert error == {:error, "The field 'at' has an invalid value '\"not a date/time\"'"}
     end
+
+    test "should be able to specify a a custom jobtype" do
+      data = %{hey: "there!"}
+      opts = [jobtype: "custom_job_type"]
+      job = Job.build_payload(Test.Worker, data, opts)
+
+      assert job.jobtype == "custom_job_type"
+    end
+
+    test "should return an error for a non binary jobtype" do
+      data = %{hey: "there!"}
+      opts = [jobtype: 1]
+      error = Job.build_payload(Test.Worker, data, opts)
+
+      assert error == {:error, "The field 'jobtype' has an invalid value '1'"}
+    end
   end
 
   describe "perform_async/2" do


### PR DESCRIPTION
Currently the worker module name is used for the `jobtype` field when building a job and sending it to Faktory. This works great when only using the Elixir Faktory client. However, when we want to push jobs from Elixir and process them in one of the other clients (i.e. python, ruby, go, etc...) we may need to set the jobtype to something specific to that client.

This update allows the `jobtype` field to be set in the following two ways.

1. When calling `perform_async`
```elixir
MyWorker.perform_async(args, jobtype: "run_fn")
```

2. As options in the `use` when defining the worker module
```elixir
defmodule MyWorker do
  use FaktoryWorker.Job,
    queue: "some_queue",
    jobtype: "run_fn"
end
```